### PR TITLE
Adjust some parts for the keep content before changelog

### DIFF
--- a/src/utils/change.test.ts
+++ b/src/utils/change.test.ts
@@ -174,6 +174,27 @@ It does cool things.
 - Initial release\n`);
     });
 
+    it('should leave different sections untouched', () => {
+      const oldChangelog = `# Changelog
+
+## [0.1.0](https://example.com/releases/tag/0.1.0) - 2024-01-01
+
+This is a special note that should not be touched.
+
+### Features
+- Initial release\n`;
+
+      const changelog = updateChangelogSection('0.1.0', '1.0.0', oldChangelog, newSection);
+      expect(changelog).toBe(`# Changelog\n\n${newSection}
+
+## [0.1.0](https://example.com/releases/tag/0.1.0) - 2024-01-01
+
+This is a special note that should not be touched.
+
+### Features
+- Initial release\n`);
+    });
+
     const changelogFiles = [
       {
         name: 'should add new section',

--- a/src/utils/change.ts
+++ b/src/utils/change.ts
@@ -112,18 +112,15 @@ export function getChangeLogSection(
   return section;
 }
 
-const CHANGELOG_ANCHOR = /^#\s*Changelog/m;
-
 export function updateChangelogSection(
   latestVersion: string,
   nextVersion: string,
   _oldChangelog: string,
   newSection: string,
 ) {
-  const anchorMatch = _oldChangelog.match(CHANGELOG_ANCHOR);
-  let preservedPretext = anchorMatch ? _oldChangelog.substring(0, anchorMatch.index).trim() : '';
+  const changelogHeadline = '# Changelog\n\n';
 
-  let oldChangelog = _oldChangelog.replace('# Changelog\n\n', '');
+  let oldChangelog = _oldChangelog.replace(changelogHeadline, '');
 
   let sections: { version: string; section: string }[] = [];
 
@@ -158,11 +155,10 @@ export function updateChangelogSection(
 
   sections = sections.sort((a, b) => semver.compare(b.version, a.version));
 
-  if (preservedPretext.length > 0) {
-    preservedPretext += '\n\n';
-  }
+  // Keep the preamble of the changelog
+  const preamble = _oldChangelog.substring(0, Math.max(_oldChangelog.indexOf(changelogHeadline), 0));
 
-  return `${preservedPretext}# Changelog\n\n${sections.map((s) => s.section).join('\n\n')}\n`;
+  return `${preamble}${changelogHeadline}${sections.map((s) => s.section).join('\n\n')}\n`;
 }
 
 export function extractVersionFromCommitMessage(commitMessage: string) {


### PR DESCRIPTION
- adjusted some nits of the js code
- added a test to check that we don't touch existing changelog sections (was already the case and would allow us to manually add some notes there as well)